### PR TITLE
wire up column labeling

### DIFF
--- a/src/SheetModel.elm
+++ b/src/SheetModel.elm
@@ -29,13 +29,19 @@ type alias Cell =
     ( CellCoords, CellElement )
 
 
-type alias SheetData =
-    Array2D Cell
+type alias ColumnLabel =
+    String
 
 
-elementAt : ( RowIx, ColIx ) -> SheetData -> Maybe CellElement
+type alias SheetEnvelope =
+    { data : Array2D Cell
+    , columnLabels : List ColumnLabel
+    }
+
+
+elementAt : ( RowIx, ColIx ) -> SheetEnvelope -> Maybe CellElement
 elementAt ( rix, cix ) sheet =
-    case Array2D.getValueAt ( rix, cix ) sheet of
+    case Array2D.getValueAt ( rix, cix ) sheet.data of
         -- throw away coords
         Just ( _, e ) ->
             Just e
@@ -44,8 +50,8 @@ elementAt ( rix, cix ) sheet =
             Nothing
 
 
-array2DToSheet : Array2D CellElement -> SheetData
-array2DToSheet arr2d =
+array2DToSheet : Array2D CellElement -> List ColumnLabel -> SheetEnvelope
+array2DToSheet arr2d colLabels =
     -- given an Array2D of elements, convert to sheet data
     -- this is useful for initialization
     let
@@ -55,11 +61,14 @@ array2DToSheet arr2d =
         nCols =
             Array2D.colCount arr2d
     in
-    AE.map2
-        (\row rix ->
-            AE.map2 (\e cix -> ( ( rix, cix ), e ))
-                row
-                (A.fromList <| List.range 0 (nCols - 1))
-        )
-        arr2d
-        (A.fromList <| List.range 0 (nRows - 1))
+    { data =
+        AE.map2
+            (\row rix ->
+                AE.map2 (\e cix -> ( ( rix, cix ), e ))
+                    row
+                    (A.fromList <| List.range 0 (nCols - 1))
+            )
+            arr2d
+            (A.fromList <| List.range 0 (nRows - 1))
+    , columnLabels = colLabels
+    }


### PR DESCRIPTION
columns are now labeled according to their DuckDB column names, and fallback to column index in the initial screen